### PR TITLE
Hotfix/fix lista eventos

### DIFF
--- a/src/core/Entities/Event.php
+++ b/src/core/Entities/Event.php
@@ -591,7 +591,7 @@ class Event extends \MapasCulturais\Entity
         $this->shortDescription = $shortDescription;
     }
 
-    public function getLongDescription(): string
+    public function getLongDescription(): ?string
     {
         return $this->longDescription;
     }

--- a/src/modules/Search/views/search/event.php
+++ b/src/modules/Search/views/search/event.php
@@ -11,8 +11,7 @@ $this->import('
     mc-breadcrumb
     mc-tab
     mc-tabs 
-    search
-    search-list
+    search 
     search-filter-event
     search-list-event 
     search-map-event 
@@ -41,11 +40,7 @@ $this->breadcrumb = [
             </template>
             <mc-tab icon="list" label="<?php i::esc_attr_e('Lista') ?>" slug="list">
                 <div class="search__tabs--list">
-                <search-list :pseudo-query="pseudoQuery" type="event" select="name,type,shortDescription,files.avatar,seals,endereco,terms" >
-                        <template #filter>
-                            <search-filter-event :pseudo-query="pseudoQuery"></search-filter-event>
-                        </template>
-                </search-list>
+                    <search-list-event :pseudo-query="pseudoQuery"></search-list-event>
                 </div>
             </mc-tab>
             <mc-tab icon="map" label="<?php i::esc_attr_e('Mapa') ?>"  slug="map">


### PR DESCRIPTION
### contexto 

1. Ao realizar o acesso na página de eventos, a api não retorna os dados dos eventos ativos

![image](https://github.com/RedeMapas/mapas/assets/3487411/2e0edf03-6a41-4038-8a21-38e2432b590b)

2. Ao realizar o cadastro de um evento o sistema retorna o seguinte erro:
![image](https://github.com/RedeMapas/mapas/assets/3487411/c323437e-3298-4a12-b9ff-67cf27130cde)

O PR resolve os dois problemas.

Segue o exemplo dos testes

![Gravaodetelade10-05-2024132730-ezgif com-video-to-gif-converter](https://github.com/RedeMapas/mapas/assets/3487411/127a00b9-b8ce-4630-a1ae-03a79c8b3076)




