### PR TITLE
fix: resolve problema de limpar filtros e continuar pesquisa

### DIFF
--- a/src/modules/Search/components/search-filter-event/script.js
+++ b/src/modules/Search/components/search-filter-event/script.js
@@ -164,14 +164,13 @@ app.component('search-filter-event', {
 
     methods: {
         clearFilters() {
-            delete this.pseudoQuery['event:@verified'];
-            delete this.pseudoQuery['event:term:linguagem'];
-            delete this.pseudoQuery['event:classificacaoEtaria'];
             this.date = [this.defaultDateFrom, this.defaultDateTo];
-            this.pseudoQuery['@from'] = this.parseDate(this.today);
-            this.pseudoQuery['@to'] = this.parseDate(this.nextMonth);
+            this.pseudoQuery['@from'] = new McDate(new Date(this.date[0])).date('sql');
+            this.pseudoQuery['@to'] = new McDate(new Date(this.date[1])).date('sql');
+            delete this.pseudoQuery['event:@verified'];
+            this.pseudoQuery['event:classificacaoEtaria'].length = 0;
+            this.pseudoQuery['event:term:linguagem'].length = 0;       
         },
-
         dateFormat(date) {
             const d0 = new Date(date[0]);
             const d1 = new Date(date[1]);


### PR DESCRIPTION
## Descrição

Na versão mais recente do mapas o problema não acontece.  https://github.com/mapasculturais/mapasculturais/tree/develop

Resolve o problema de ao aplicar o filtro e limpar, os campos devem continuar com valores nas options para realizar uma nova busca. Atualmente limpa os campos, mas zera os valores.

## Validação

Para validar é necessário entrar especificamente na página de eventos, adicionar filtros, limpar os filtros e em seguida realizar uma nova pesquisa.

## Issues relacionadas

https://github.com/LabCDBr/gestao/issues/412
