### PR TITLE
Integração contínua Cypress + GitHub Actions / Versão com Screenshots 

### DIFF
--- a/.github/workflows/ci-cypress.yml
+++ b/.github/workflows/ci-cypress.yml
@@ -1,0 +1,25 @@
+name: End-to-end tests
+on: push
+jobs:
+  cypress-run:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      # Install npm dependencies, cache them correctly
+      # and run all Cypress tests
+      - name: Cypress run
+        uses: cypress-io/github-action@v6
+      
+      - uses: actions/upload-artifact@v4
+        # add the line below to store screenshots only on failures
+        if: failure()
+        with:
+            name: cypress-screenshots
+            path: cypress/screenshots
+            if-no-files-found: ignore # 'warn' or 'error' are also available, defaults to `warn`
+      - uses: actions/upload-artifact@v4
+        with:
+            name: cypress-videos
+            path: cypress/videos
+            if-no-files-found: ignore # 'warn' or 'error' are also available, defaults to `warn`

--- a/.github/workflows/ci-cypress.yml
+++ b/.github/workflows/ci-cypress.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Instala as dependências, cria configs e executa testes
-        run: cd src/ && npm install && npx cypress run --spec "cypress/e2e/agentesPage/*.js"
+        run: cd src/ && npm install && npx cypress run --spec "cypress/e2e/**/*.js"
 
       - name: Cypress Screenshots
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-cypress.yml
+++ b/.github/workflows/ci-cypress.yml
@@ -5,10 +5,7 @@ on:
     branches:
       - 'main'
       - 'feature/upgrade-cypress'
-  push:
-    branches:
-      - 'main'
-      - 'feature/upgrade-cypress'
+
 jobs:
   cypress-run:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-cypress.yml
+++ b/.github/workflows/ci-cypress.yml
@@ -17,12 +17,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Instala as dependências, cria configs e executa testes
-        run: cd src/ && npm install && npx cypress run --spec "cypress/e2e/**/*.js"
+        run: cd src/ && npm install && npx cypress run --spec "cypress/e2e/agentesPage/*.js"
 
       - name: Cypress Screenshots
         uses: actions/upload-artifact@v4
         if: failure()
         with:
             name: cypress-screenshots
-            path: cypress/screenshots
+            path: src/cypress/screenshots
             if-no-files-found: ignore

--- a/.github/workflows/ci-cypress.yml
+++ b/.github/workflows/ci-cypress.yml
@@ -1,25 +1,28 @@
-name: End-to-end tests
-on: push
+name: cypress-ci
+
+on:
+  pull_request:
+    branches:
+      - 'main'
+      - 'feature/upgrade-cypress'
+  push:
+    branches:
+      - 'main'
+      - 'feature/upgrade-cypress'
 jobs:
   cypress-run:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Git Checkout
         uses: actions/checkout@v4
-      # Install npm dependencies, cache them correctly
-      # and run all Cypress tests
-      - name: Cypress run
-        uses: cypress-io/github-action@v6
-      
-      - uses: actions/upload-artifact@v4
-        # add the line below to store screenshots only on failures
+
+      - name: Instala as dependências, cria configs e executa testes
+        run: cd src/ && npm install && npx cypress run --spec "cypress/e2e/**/*.js"
+
+      - name: Cypress Screenshots
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
             name: cypress-screenshots
             path: cypress/screenshots
-            if-no-files-found: ignore # 'warn' or 'error' are also available, defaults to `warn`
-      - uses: actions/upload-artifact@v4
-        with:
-            name: cypress-videos
-            path: cypress/videos
-            if-no-files-found: ignore # 'warn' or 'error' are also available, defaults to `warn`
+            if-no-files-found: ignore

--- a/src/cypress/e2e/agentesPage/compact.cy.js
+++ b/src/cypress/e2e/agentesPage/compact.cy.js
@@ -17,6 +17,6 @@ describe("Pagina de Agentes", () => {
 
     it("clica em \"Acessar\" e entra na pagina no agente selecionado", () => {
         cy.get(":nth-child(2) > .entity-card__footer > .entity-card__footer--action > .button").click();
-        cy.contains("Informações");
+        cy.contains("Informaçõeuhyg");
     });
 });

--- a/src/cypress/e2e/agentesPage/compact.cy.js
+++ b/src/cypress/e2e/agentesPage/compact.cy.js
@@ -17,6 +17,6 @@ describe("Pagina de Agentes", () => {
 
     it("clica em \"Acessar\" e entra na pagina no agente selecionado", () => {
         cy.get(":nth-child(2) > .entity-card__footer > .entity-card__footer--action > .button").click();
-        cy.contains("Informaçõeuhyg");
+        cy.contains("Informações");
     });
 });


### PR DESCRIPTION
## Descrição

Foi feito um gh pr checkout do pull request anterior e adicionado a feature de tirar screenshots dos testes que retornarem erro. Desta forma, é possível visualizar o erro através da interface do cypress.

## Validação

Na aba "Actions", em um workflow específico, caso ocorra um erro, a seção "Artifacts" se torna visível e disponibiliza um arquivo compactado com as screenshots desse erro para download.

## Issues relacionadas
[Issue LabCDBr/transfer#18](
https://github.com/LabCDBr/transfer/issues/18)