### PR TITLE
habilita hooks entity insert - para permitir gerenciamento de oportunidades

### DIFF
--- a/src/core/Entity.php
+++ b/src/core/Entity.php
@@ -1215,12 +1215,12 @@ abstract class Entity implements \JsonSerializable{
         
         $hook_prefix = $this->getHookPrefix();
 
-//        $app->applyHookBoundTo($this, "{$hook_prefix}.insert:after");
-//
-//        if ($this->usesPermissionCache()) {
-//            $this->createPermissionsCacheForUsers([$this->ownerUser]);
-//            $app->enqueueEntityToPCacheRecreation($this);
-//        }
+        $app->applyHookBoundTo($this, "{$hook_prefix}.insert:after");
+
+        if ($this->usesPermissionCache()) {
+            $this->createPermissionsCacheForUsers([$this->ownerUser]);
+            $app->enqueueEntityToPCacheRecreation($this);
+        }
     }
 
     /**


### PR DESCRIPTION
## Descrição

Adicionar no postPersist os hooks insert:after que permite ser executado a após inserir um registro.
Atualização resolve o problema de gerenciamento das oportunidades, permitindo gerenciar as fases.

## Screenshots

### Problema

![Gravaodetelade11-06-2024090802-ezgif com-video-to-gif-converter](https://github.com/RedeMapas/mapas/assets/3487411/944f6f72-546f-49da-9b47-7aa161c03f48)


### Solução aplicada

![Gravaodetelade11-06-2024090930-ezgif com-video-to-gif-converter](https://github.com/RedeMapas/mapas/assets/3487411/72c898ab-3133-42e2-b5d8-ce363f929f2e)


## Validação

Criar uma oportunidade e o sistema permitir gerenciar fases (simplificada, técnica e etc)

## Issues relacionadas

#168 