### PR TITLE
Feature/opportunity dashboards search

### DIFF
--- a/dev/config.d/Metabase.php
+++ b/dev/config.d/Metabase.php
@@ -240,8 +240,41 @@ return [
                                 ],
                             ]
                         ],
+                        [
+                            'type' => 'opportunity',
+                            'label' => 'Oportunidades',
+                            'icon'=> 'opportunity',
+                            'iconClass'=> 'opportunity__color',
+                            'panelLink'=> 'painel-oportunidades',
+                            'data'=> [
+                                [
+                                    'icon'=> 'opportunity',
+                                    'label' => 'Oportunidades criadas',
+                                    'entity' => 'MapasCulturais\\Entities\\Opportunity',
+                                    'query' => [],
+                                    'value' => null
+                                ],
+                            ]
+                        ],
+                        [
+                            'type' => 'opportunity',
+                            'label' => 'Oportunidades certificadas',
+                            'icon'=> 'opportunity',
+                            'iconClass'=> 'opportunity__color',
+                            'panelLink'=> 'painel-oportunidades',
+                            'data'=> [
+                                [
+                                    'icon'=> 'opportunity',
+                                    'label' => 'Oportunidades certificadas',
+                                    'entity' => 'MapasCulturais\\Entities\\Opportunity',
+                                    'query'=> [
+                                        '@verified'=> 1
+                                    ],
+                                    'value' => null
+                                ],
+                            ]
+                        ]
                     ]
-                
             ]
         ]
     ]

--- a/src/cypress/e2e/opportunityPage/index.cy.js
+++ b/src/cypress/e2e/opportunityPage/index.cy.js
@@ -11,4 +11,29 @@ describe("Oportunidade", () => {
         cy.wait(1000);
         cy.url().should("include", "/oportunidade/");
     });
+
+    it("Garante que os cards de indicadores das oportunidades funciona", () => {
+        cy.visit("/oportunidades");
+        cy.get(':nth-child(1) > .entity-cards-cards__content > .entity-cards-cards__info > .entity-cards-cards__label').should('have.text', 'Oportunidades criadas');
+        cy.get(':nth-child(2) > .entity-cards-cards__content > .entity-cards-cards__info > .entity-cards-cards__label').should('have.text', 'Oportunidades certificadas');
+
+        cy.wait(1000);
+
+        cy.get(".foundResults").invoke('text').then((text) => {
+            let expectedCount = Number(text.match(/\d+/), 10);
+            console.log(expectedCount);
+            cy.get('#main-app > div.search > div.entity-cards > div > div > div:nth-child(1) > div > div.entity-cards-cards__info > strong').should('have.text', expectedCount);
+        });
+
+    });
+
+    it("Garante que a tab dashboard de oportunidades funciona", () => {
+        cy.visit("/oportunidades");
+        cy.get('.indicator > a > span').should('have.text', 'Indicadores');
+        cy.get('.indicator > a').click();
+
+        cy.wait(1000);
+
+        cy.get('#iFrameResizer0').should('be.visible');
+    });
 });

--- a/src/modules/Search/views/search/opportunity.php
+++ b/src/modules/Search/views/search/opportunity.php
@@ -7,6 +7,8 @@ $this->import('
     search-filter-opportunity
     search-list
     search-map
+    mc-tab
+    mc-tabs 
 ');
 
 $this->breadcrumb = [
@@ -24,16 +26,23 @@ $this->breadcrumb = [
         </create-opportunity>
     </template>
     <template #default="{pseudoQuery, entity}">
-        <div class="tabs-component__panels">
-            <div class="search__tabs--list">
-                <search-list :pseudo-query="pseudoQuery" type="opportunity" select="name,type,shortDescription,files.avatar,seals,terms,registrationFrom,registrationTo">
-                    <template #filter>
-                        
-
-                        <search-filter-opportunity :pseudo-query="pseudoQuery"></search-filter-opportunity>
-                    </template>
-                </search-list>
-            </div>
-        </div>
+        <mc-tabs class="search__tabs" sync-hash>
+            <template #before-tablist>
+                <label class="search__tabs--before">
+                    <?= i::_e('Visualizar como:') ?>
+                </label>
+            </template>
+            <?php $this->applyTemplateHook('search-tabs', 'before'); ?>
+            <mc-tab icon="list" label="<?php i::esc_attr_e('Lista') ?>" slug="list">
+                <div class="search__tabs--list">
+                    <search-list :pseudo-query="pseudoQuery" type="opportunity" select="name,type,shortDescription,files.avatar,seals,terms,registrationFrom,registrationTo">
+                        <template #filter>
+                            <search-filter-opportunity :pseudo-query="pseudoQuery"></search-filter-opportunity>
+                        </template>
+                    </search-list>
+                </div>
+            </mc-tab>
+            <?php $this->applyTemplateHook('search-tabs', 'after'); ?>
+        </mc-tabs>
     </template>
 </search>

--- a/src/plugins/Metabase/Plugin.php
+++ b/src/plugins/Metabase/Plugin.php
@@ -27,12 +27,20 @@ class Plugin extends \MapasCulturais\Plugin
             $this->part('search-tabs/agent');
         });
 
+        $app->hook('template(search.opportunities.search-tabs):after', function(){
+            $this->part('search-tabs/opportunity');
+        });
+
         // $app->hook('template(search.spaces.search-tabs):after', function(){
         //     $this->part('search-tabs/space');
         // });
 
         $app->hook('template(search.agents.search-header):after', function(){
             $this->part('search-tabs/entity-agent-cards');
+        });
+
+        $app->hook('template(search.opportunities.search-header):after', function(){
+            $this->part('search-tabs/entity-opportunity-cards');
         });
 
         // $app->hook('template(search.spaces.search-header):after', function(){

--- a/src/plugins/Metabase/layouts/parts/search-tabs/entity-opportunity-cards.php
+++ b/src/plugins/Metabase/layouts/parts/search-tabs/entity-opportunity-cards.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @var MapasCulturais\App $app
+ * @var MapasCulturais\Themes\BaseV2\Theme $this
+ */
+
+use MapasCulturais\i;
+
+$this->import('
+    entity-cards
+');
+?>
+<entity-cards type="opportunity"></entity-cards>

--- a/src/plugins/Metabase/layouts/parts/search-tabs/opportunity.php
+++ b/src/plugins/Metabase/layouts/parts/search-tabs/opportunity.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * @var MapasCulturais\App $app
+ * @var MapasCulturais\Themes\BaseV2\Theme $this
+ */
+
+use MapasCulturais\i;
+
+$this->import('
+    search-dashboard
+');
+
+?>
+<mc-tab icon="indicator" label="<?php i::esc_attr_e('Indicadores') ?>" slug="indicator">
+    <div class="search__tabs--indicator">
+       <search-dashboard panel-Id="painel-oportunidades"></search-dashboard>
+    </div>
+</mc-tab>

--- a/src/themes/BaseV2/assets-src/sass/pages/_search.scss
+++ b/src/themes/BaseV2/assets-src/sass/pages/_search.scss
@@ -584,17 +584,16 @@
     .search {
         .tabs-component__panels {
             background: var(--mc-gray-100);
-            margin-top: size(88);
             padding-bottom: size(40);
             margin-bottom: 0;
             min-height: size(500);
 
             @media (max-width: size(800)) {
-                margin-top: size(123);
+                margin-top: size(5);
             }
 
             @media (max-width: size(500)) {
-                margin-top: size(130);
+                margin-top: size(5);
             }
         }
 


### PR DESCRIPTION
## Descrição

Adiciona configuração do plugin do metabase os cards de indicadores na pesquisa da entidade (oportunidades) e adiciona tab para o dashboard da entidade.

## Validação

Acessar página de pesquisa de oportunidades e na tela página inicial deve aparecer os cards contendo os indicadores do mapas:

- Oportunidades criadas
- Oportunidades certificadas

## Issues relacionadas

- https://github.com/RedeMapas/mapas/issues/228
- https://github.com/RedeMapas/mapas/issues/229
