### PR TITLE
feat: desabilita estilo de tipo de entidade

### DIFF
--- a/src/modules/Search/components/search-list/template.php
+++ b/src/modules/Search/components/search-list/template.php
@@ -77,7 +77,7 @@ $this->import('
                         <template #avatar>
                             <mc-avatar :entity="entity" size="medium"></mc-avatar>
                         </template>
-                        <template #type> <span>{{typeText}} <span :class="['upper', entity.__objectType+'__color']">{{entity.type?.name}}</span></span></template>
+                        <template #type> <span>{{typeText}} <span :class="['upper']">{{entity.type?.name}}</span></span></template>
                     </entity-card>
                 </div>
             </div>


### PR DESCRIPTION
## Descrição

Desabilita estilo no tipo da entidade de acordo com a solicitação na issue https://github.com/RedeMapas/mapas/issues/71

## Validação

Acessar listagem de qualquer entidade e verificar o estilo

![image](https://github.com/RedeMapas/mapas/assets/3487411/fd4ed4e7-c1f8-4d11-ac30-dec59d914a53)

## Issues relacionadas

https://github.com/RedeMapas/mapas/issues/71