### PR TITLE
FIX - não permitir cadastros de inscrições já encerradas

### DIFF
--- a/src/modules/Opportunities/components/opportunity-basic-info/script.js
+++ b/src/modules/Opportunities/components/opportunity-basic-info/script.js
@@ -28,6 +28,15 @@ app.component('opportunity-basic-info' , {
         lastPhase () {
             const phase = this.phases.find(item => item.isLastPhase);
             return phase;
-        }
+        },
+		today() {
+			return new Date();
+		},
+		registrationToMinDate() {
+			return this.entity.registrationFrom?._date &&
+				this.entity.registrationFrom?._date > this.today
+				? this.entity.registrationFrom?._date
+				: this.today;
+		},
     }
 });

--- a/src/modules/Opportunities/components/opportunity-basic-info/template.php
+++ b/src/modules/Opportunities/components/opportunity-basic-info/template.php
@@ -39,10 +39,10 @@ $this->import('
             <?php $this->applyTemplateHook('opportunity-basic-info','before')?>
             <div class="grid-12">
                 <?php $this->applyTemplateHook('opportunity-basic-info','begin')?>
-                <entity-field :entity="entity" prop="registrationFrom" :max="entity.registrationTo?._date" :autosave="3000" classes="col-6 sm:col-12"></entity-field>
-                <entity-field :entity="entity" prop="registrationTo" :min="entity.registrationFrom?._date" :autosave="3000" classes="col-6 sm:col-12"></entity-field>
+                <entity-field :entity="entity" prop="registrationFrom" :min="today" :max="entity.registrationTo?._date" :autosave="3000" classes="col-6 sm:col-12"></entity-field>
+                <entity-field :entity="entity" prop="registrationTo" :min="registrationToMinDate" :autosave="3000" classes="col-6 sm:col-12"></entity-field>
 
-                <entity-field v-if="lastPhase" :entity="lastPhase" prop="publishTimestamp" :autosave="3000" classes="col-6">
+                <entity-field v-if="lastPhase" :entity="lastPhase" prop="publishTimestamp" :min="this.entity.registrationTo?._date || today" :autosave="3000" classes="col-6">
                     <label><?= i::__("Publicação final de resultados (data e hora)") ?></label>
                 </entity-field>
                 <?php $this->applyTemplateHook('opportunity-basic-info','afeter')?>


### PR DESCRIPTION
## Descrição

Não é mais possível selecionar uma data de inscrição anterior ao dia atual.
A data em que se encerram as inscrições continua sendo uma data após a data da inscrição.
Não é mais possível selecionar uma data de publicação anterior ao da data de término das inscrições.

## Validação

![image](https://github.com/user-attachments/assets/55234789-9394-48c5-81b2-306d711795a3)

## Issue
[OPORTUNIDADE] Não permitir o cadastro de uma oportunidade com inscrições já encerradas. #47