### PR TITLE
FIX - Atualiza mensagem de erro para imagens de formato inválido

### DIFF
--- a/src/core/App.php
+++ b/src/core/App.php
@@ -2315,15 +2315,15 @@ class App {
         // all file groups
         $file_groups = [
             'downloads' => new Definitions\FileGroup('downloads'),
-            'avatar' => new Definitions\FileGroup('avatar', ['^image/(jpeg|png)$'], i::__('O arquivo enviado não é uma imagem válida.'), true),
-            'header' => new Definitions\FileGroup('header', ['^image/(jpeg|png)$'], i::__('O arquivo enviado não é uma imagem válida.'), true),
-            'gallery' => new Definitions\FileGroup('gallery', ['^image/(jpeg|png)$'], i::__('O arquivo enviado não é uma imagem válida.'), false),
+            'avatar' => new Definitions\FileGroup('avatar', ['^image/(jpeg|png)$'], i::__('Formato de imagem inválido. Insira imagens nos formatos JPG ou PNG.'), true),
+            'header' => new Definitions\FileGroup('header', ['^image/(jpeg|png)$'], i::__('Formato de imagem inválido. Insira imagens nos formatos JPG ou PNG.'), true),
+            'gallery' => new Definitions\FileGroup('gallery', ['^image/(jpeg|png)$'], i::__('Formato de imagem inválido. Insira imagens nos formatos JPG ou PNG.'), false),
             'registrationFileConfiguration' => new Definitions\FileGroup('registrationFileTemplate', ['^application/.*'], i::__('O arquivo enviado não é um documento válido.'), true),
             'rules' => new Definitions\FileGroup('rules', ['^application/.*'], i::__('O arquivo enviado não é um documento válido.'), true),
-            'logo'  => new Definitions\FileGroup('logo',['^image/(jpeg|png)$'], i::__('O arquivo enviado não é uma imagem válida.'), true),
-            'background' => new Definitions\FileGroup('background',['^image/(jpeg|png)$'], i::__('O arquivo enviado não é uma imagem válida.'),true),
-            'share' => new Definitions\FileGroup('share',['^image/(jpeg|png)$'], i::__('O arquivo enviado não é uma imagem válida.'),true),
-            'institute'  => new Definitions\FileGroup('institute',['^image/(jpeg|png)$'], i::__('O arquivo enviado não é uma imagem válida.'), true),
+            'logo'  => new Definitions\FileGroup('logo',['^image/(jpeg|png)$'], i::__('Formato de imagem inválido. Insira imagens nos formatos JPG ou PNG.'), true),
+            'background' => new Definitions\FileGroup('background',['^image/(jpeg|png)$'], i::__('Formato de imagem inválido. Insira imagens nos formatos JPG ou PNG.'),true),
+            'share' => new Definitions\FileGroup('share',['^image/(jpeg|png)$'], i::__('Formato de imagem inválido. Insira imagens nos formatos JPG ou PNG.'),true),
+            'institute'  => new Definitions\FileGroup('institute',['^image/(jpeg|png)$'], i::__('Formato de imagem inválido. Insira imagens nos formatos JPG ou PNG.'), true),
             'favicon'  => new Definitions\FileGroup('favicon',['^image/(jpeg|png|x-icon|vnd.microsoft.icon)$'], i::__('O arquivo enviado não é uma imagem válida.'), true),
             'zipArchive'  => new Definitions\FileGroup('zipArchive',['^application/zip$'], i::__('O arquivo não é um ZIP.'), true, null, true),
         ];

--- a/src/modules/Components/assets/js/components-base/Entity.js
+++ b/src/modules/Components/assets/js/components-base/Entity.js
@@ -145,7 +145,14 @@ class Entity {
     }
 
     catchErrors(res, data) {
-        const message = data.data.message;
+        const message = data.data.message ??
+		data.data.avatar ??
+		data.data.header ??
+		data.data.gallery ??
+		data.data.logo ??
+		data.data.background ??
+		data.data.share ??
+		data.data.institute; // getting errors from validation errors;
         
         if (res.status >= 500 && res.status <= 599) {
             this.sendMessage(message || this.text('erro inesperado'), 'error');


### PR DESCRIPTION
## Descrição
Atualização na função catchErrors do arquivo Entity.js.
Agora o arquivo verifica se existe mensagem de erro dos Validators também.
Desse modo, ao inserir uma imagem de formato inválido, o Validator verifica que o formato é inadequado e retorna a mensagem padrão, indicando os tipos permitidos.
![image](https://github.com/user-attachments/assets/db4d92b7-6886-4393-80f6-4355d6afbbd7)

## Validação
Tentativa de upload de imagem .webp, retornando mensagem de erro.
![名称未設定](https://github.com/user-attachments/assets/cdd7b9e1-388f-4545-9209-fc62aa382127)

## Issues relacionadas
[AGENTE] Feedback impreciso ao tentar cadastrar imagem com formato não aceito. #69 