### PR TITLE
Remoção de termo duplicado no aviso de rascunho da publicação de opor…

### DIFF
--- a/src/modules/Entities/components/entity-status/template.php
+++ b/src/modules/Entities/components/entity-status/template.php
@@ -61,7 +61,7 @@ $this->import('
         <template v-if="entity.__objectType == 'project'">
             <span v-if="entity.status == 0">
                 <strong><?= i::__('Este projeto está em rascunho.'); ?></strong>
-                <?= i::__('Você Você precisa <strong>publicar</strong> para exibir para todas as pessoas.') ?>
+                <?= i::__('Você precisa <strong>publicar</strong> para exibir para todas as pessoas.') ?>
             </span>
             <span v-if="entity.status == -10">
                 <strong><?= i::__('Este projeto está na lixeira.'); ?></strong>
@@ -75,15 +75,15 @@ $this->import('
 
         <template v-if="entity.__objectType == 'opportunity'">
             <span v-if="entity.status == 0">
-                <strong><?= i::__('Este oportunidade está em rascunho.'); ?></strong>
-                <?= i::__('Você Você precisa <strong>publicar</strong> para exibir para todas as pessoas.') ?>
+                <strong><?= i::__('Esta oportunidade está em rascunho.'); ?></strong>
+                <?= i::__('Você precisa <strong>publicar</strong> para exibir para todas as pessoas.') ?>
             </span>
             <span v-if="entity.status == -10">
-                <strong><?= i::__('Este oportunidade está na lixeira.'); ?></strong>
+                <strong><?= i::__('Esta oportunidade está na lixeira.'); ?></strong>
                 <?= i::__('Você pode <strong>recuperar</strong> ou <strong>excluir em definitivo</strong>') ?>
             </span>
             <span v-if="entity.status == -2">
-            <strong><?= i::__('Este oportunidade está arquivada.'); ?></strong>
+            <strong><?= i::__('Esta oportunidade está arquivada.'); ?></strong>
                 <?= i::__('Você pode <strong>publicar</strong> novamente para desarquivá-la.') ?>
             </span>
         </template>

--- a/src/modules/Opportunities/components/opportunity-basic-info/template.php
+++ b/src/modules/Opportunities/components/opportunity-basic-info/template.php
@@ -45,7 +45,7 @@ $this->import('
                 <entity-field v-if="lastPhase" :entity="lastPhase" prop="publishTimestamp" :autosave="3000" classes="col-6">
                     <label><?= i::__("Publicação final de resultados (data e hora)") ?></label>
                 </entity-field>
-                <?php $this->applyTemplateHook('opportunity-basic-info','afeter')?>
+                <?php $this->applyTemplateHook('opportunity-basic-info','after')?>
             </div>
             <?php $this->applyTemplateHook('opportunity-basic-info','end')?>
         </template>


### PR DESCRIPTION
…tunidades

## Descrição

O termo 'Você' estava duplicado no aviso de rascunho quando se publica uma oportunidade, então corrigi isso. O problema relatado na issue é que o aviso não desaparece quando se publica a oportunidade. Isso se deve ao fato de que o status da entidade é atualizado apenas quando a página é recarregada, ou seja, com um F5 o problema é resolvido.

## Validação

A alteração ocorreu como esperado, rodando o Mapas localmente.

## Issues relacionadas

https://github.com/RedeMapas/mapas/issues/42