### PR TITLE
FIX - update no estilo do botão de conheca o repositorio na Home

### DIFF
--- a/src/modules/Home/components/home-developers/template.php
+++ b/src/modules/Home/components/home-developers/template.php
@@ -1,19 +1,21 @@
 <?php
+
 /**
  * @var MapasCulturais\App $app
  * @var MapasCulturais\Themes\BaseV2\Theme $this
  */
+
 use MapasCulturais\i;
 ?>
-<div class="home-developers"> 
+<div class="home-developers">
     <div class="home-developers__content">
         <span class="dev-icon"><mc-icon name="code"></mc-icon></span>
-        <label class="home-developers__content--title"><?= $this->text('title',i::__('Alô desenvolvedores')) ?></label>
+        <label class="home-developers__content--title"><?= $this->text('title', i::__('Alô desenvolvedores')) ?></label>
         <div class="home-developers__content--description">
-            <?= $this->text('description',i::__('Além disso, Mapas Culturais é um software livre, criado em parceria entre a hacklab/, secretarias de cultura, organizações não governamentais, empresas e coletivos que investem na plataforma. Você pode contribuir para o seu desenvolvimento através do GitHub.')) ?>
+            <?= $this->text('description', i::__('Além disso, Mapas Culturais é um software livre, criado em parceria entre a hacklab/, secretarias de cultura, organizações não governamentais, empresas e coletivos que investem na plataforma. Você pode contribuir para o seu desenvolvimento através do GitHub.')) ?>
         </div>
         <div class="home-developers__content--link">
-            <a class="link" href="https://github.com/mapasculturais"> 
+            <a class="link github-btn button button--primary-outline button--icon" href="https://github.com/mapasculturais">
                 <?php i::_e("Conheça o repositório") ?>
                 <mc-icon name="github"></mc-icon>
             </a>

--- a/src/themes/BaseV2/assets-src/sass/2.components/_home-developers.scss
+++ b/src/themes/BaseV2/assets-src/sass/2.components/_home-developers.scss
@@ -55,6 +55,9 @@
                 line-height: size(25);
                 text-decoration: none;
             }
+			.github-btn:hover {
+				color: var(--mc-white);
+			}
         }
     }
 }


### PR DESCRIPTION
## Descrição

Modifica o estilo do link de "Conheça o repositório" na página Home, deixando-o no formato de um botão para evidenciar que trata-se de um hiperlink.

## Validação

![download](https://github.com/user-attachments/assets/3b8da870-3b0e-4caa-8fe5-040fdbe9a16f)

## Issues relacionadas

[HOME] Atribuir tratamento de hiperlink para link do repositório na home. #65