### PR TITLE
FIX - dropdown de Tipos de espaço agora aparecem em ordem alfabética

### DIFF
--- a/src/core/App.php
+++ b/src/core/App.php
@@ -3324,8 +3324,12 @@ class App {
      * @return Definitions\EntityType[]
      */
     function getRegisteredEntityTypes(Entity|string $entity): array {
-        if(is_object($entity))
+        if (is_object($entity))
             $entity = $entity->getClassName();
+
+        usort($this->_register['entity_types'][$entity], function ($a, $b) {
+            return strcmp($a->name, $b->name);
+        });
 
         return $this->_register['entity_types'][$entity] ?? [];
     }


### PR DESCRIPTION
## Descrição

Insere função usort dentro da função getRegisteredEntityTypes no arquivo app.php para ordenar as entidades por ordem alfabética baseado na propriedade "name" do objeto.

![Screenshot from 2024-07-15 14-47-33](https://github.com/user-attachments/assets/4a34cc79-5cc3-4d49-8f01-f1a4c51e0d4b)

## Validação

![名称未設定](https://github.com/user-attachments/assets/ed99f3f9-2963-444d-b308-680ed4a3c60b)

## Issues relacionadas

[ESPAÇOS] Dropdown de "Tipo de espaço" não está em ordem alfabética #101