### PR TITLE
76 projetos na tela de detalhes do projeto indicar quantidade de subprojetos vinculados

### DIFF
--- a/src/modules/Entities/views/project/single.php
+++ b/src/modules/Entities/views/project/single.php
@@ -35,6 +35,7 @@ $this->breadcrumb = [
     ['label' => $label, 'url' => $app->createUrl('search', 'projects')],
     ['label' => $entity->name, 'url' => $app->createUrl('project', 'single', [$entity->id])],
 ];
+
 ?>
 
 <div class="main-app">
@@ -44,7 +45,7 @@ $this->breadcrumb = [
             <dl v-if="entity.id && global.showIds[entity.__objectType]" class="metadata__id">
                 <dt class="metadata__id--id"><?= i::__('ID') ?></dt>
                 <dd><strong>{{entity.id}}</strong></dd>
-            </dl> 
+            </dl>
             <dl v-if="entity.type">
                 <dt><?= i::__('Tipo') ?></dt>
                 <dd :class="[entity.__objectType+'__color', 'type']"> {{entity.type.name}} </dd>
@@ -68,7 +69,7 @@ $this->breadcrumb = [
                                 <div v-if="entity.telefonePublico" class="additional-info__item">
                                     <p class="additional-info__item__title"><?php i::_e("telefone:"); ?></p>
                                     <p class="additional-info__item__content">{{entity.telefonePublico}}</p>
-                                </div>  
+                                </div>
 
                                 <div v-if="entity.emailPublico" class="additional-info__item">
                                     <p class="additional-info__item__title"><?php i::_e("email:"); ?></p>
@@ -105,25 +106,24 @@ $this->breadcrumb = [
                 </mc-container>
             </div>
         </mc-tab>
-
-        <mc-tab label="<?= i::_e('Subprojetos') ?>" slug="subprojects">
+        <mc-tab label="<?= i::_e('Subprojetos') ?> (<?= count($entity->children) ?>)" slug=" subprojects">
             <div class="single-project__subproject">
                 <mc-container>
                     <main class="grid-12">
-                        <mc-entities v-if="entity.children" type="project" select="name,type,shortDescription,files.avatar,seals,terms" :query="{id: `IN(${entity.children})`}" :limit="20" watch-query>
+                        <mc-entities v-if="entity.children" type="project" select="name,type,shortDescription,files.avatar,seals,terms" :query="{id: `IN(${entity.children.map((c) => c._id)})`}" :limit="20" watch-query>
                             <template #default="{entities}">
                                 <entity-card :entity="entity" v-for="entity in entities" :key="entity.__objectId" class="col-12">
                                     <template #avatar>
                                         <mc-avatar :entity="entity" size="medium"></mc-avatar>
                                     </template>
-                                    <template #type> 
-                                        <span> 
-                                            <?= i::__('TIPO: ') ?> 
+                                    <template #type>
+                                        <span>
+                                            <?= i::__('TIPO: ') ?>
                                             <span :class="['upper', entity.__objectType+'__color']">{{entity.type.name}}</span>
                                         </span>
                                     </template>
                                 </entity-card>
-                            </template>                                
+                            </template>
                         </mc-entities>
 
                         <div v-if="!entity.children" class="single-project__not-found">

--- a/src/modules/Search/views/search/project.php
+++ b/src/modules/Search/views/search/project.php
@@ -26,9 +26,9 @@ $this->breadcrumb = [
         </create-project>
     </template>
     <template #default="{pseudoQuery}">
-        <div class="tabs-component__panels">
+        <div class="tabs-component__panels" style="margin-top: 90px;">
             <div class="search__tabs--list">
-                <search-list :pseudo-query="pseudoQuery" type="project" select="name,type,shortDescription,files.avatar,seals,terms" >
+                <search-list :pseudo-query="pseudoQuery" type="project" select="name,type,shortDescription,files.avatar,seals,terms">
                     <template #filter>
                         <search-filter-project :pseudo-query="pseudoQuery"></search-filter-project>
                     </template>


### PR DESCRIPTION
## Descrição

Corrige 3 Issues:

Adiciona um contador de subprojetos na aba de detalhes de projetos
![Screenshot from 2024-07-17 10-49-01](https://github.com/user-attachments/assets/96c1499f-6e2c-4f02-9093-a22c66d56163)

Corrige bug em que os subprojetos não apareciam na tela de detalhes dos projetos pois a consulta ao banco de dados estava incorreta. A alteração consiste em passar os Ids dos projetos na query ao invés dos objetos inteiros.
![Screenshot from 2024-07-17 10-40-16](https://github.com/user-attachments/assets/feec1096-1c99-41a5-96dc-cd7a7b877014)

Adiciona uma margem para a barra de pesquisa não sobrepor o botão de criar projeto
![Screenshot from 2024-07-16 10-37-09](https://github.com/user-attachments/assets/28878ad4-faf4-4dd4-9d6f-1fb25c20f16d)

## Validação

Contador de subprojetos (com subprojetos sendo carregados):
![image](https://github.com/user-attachments/assets/a7de93ec-7fa0-4325-89b4-a476a3bf0626)

Barra de pesquisa sendo mostrada na posição correta:
![image](https://github.com/user-attachments/assets/a8ae56e4-7b7c-4644-a9bf-098005b40c09)

## Issues relacionadas

[PROJETOS] Na tela de detalhes do projeto, indicar quantidade de subprojetos vinculados. #76
[Projeto] - A aba de subprojetos, nos detalhes de um projeto, não carrega #313
[PROJETO] - Barra de pesquisa está aparecendo sobre o botão "Criar projeto" na página de Projetos #312