### PR TITLE
FIX - indicativo de resultados da search

### DIFF
--- a/src/themes/BaseV2/assets-src/sass/pages/_search.scss
+++ b/src/themes/BaseV2/assets-src/sass/pages/_search.scss
@@ -228,7 +228,6 @@
                     }
 
                     .foundResults {
-                        background-color: var(--mc-white);
                         border-radius: var(--mc-border-radius-sm);
                         font-weight: 700;
                         font-size: size(14);


### PR DESCRIPTION
## Descrição

Altera o estilo do texto que mostra a quantidade de itens mostrados na página (simplesmente remove o fundo braco).

## Validação

![image](https://github.com/user-attachments/assets/3d5e4e3d-007d-427a-a009-746bb6595a43)

## Issues relacionadas

[ESPAÇOS] Indicativo de quantidade de resultados encontrados parece um botão #109