### PR TITLE
FIX - altera estilo do link do espaco

### DIFF
--- a/src/themes/BaseV2/assets-src/sass/2.components/_entity-header.scss
+++ b/src/themes/BaseV2/assets-src/sass/2.components/_entity-header.scss
@@ -94,12 +94,12 @@
                     }
 
                     a {
-                        align-items: center;
-                        display: flex;
-                        text-decoration: none;
-                        font-weight: 600;
-                        color: var(--mc-low-500);
-                    }
+						align-items: center;
+						display: flex;
+						text-decoration: none;
+						font-weight: 600;
+						color: var($helper-500);
+					}
                 }
 
                 .title {

--- a/src/themes/BaseV2/assets-src/sass/2.components/_home-feature.scss
+++ b/src/themes/BaseV2/assets-src/sass/2.components/_home-feature.scss
@@ -132,9 +132,14 @@
 				&__track {
 					align-items: flex-start;
 				}
+				
+				&__prev--in-active,
+                &__next--in-active {
+                    cursor: default;
+                    opacity: .3;
+                    pointer-events: none;
+                }
 			}
-
 		}
-
 	}
 }


### PR DESCRIPTION
## Descrição

Altera a cor do link da tela de espaços para um azul claro, indicando que é um link clicável

## Validação

![image](https://github.com/user-attachments/assets/0cde7c20-0af6-49ee-a7f3-0e74fd1c1da9)

## Issues relacionadas

[ESPAÇOS] Aplicar cor de link nos link do Espaço #110