### PR TITLE
[ESPAÇOS] Alterar indicação de obrigatoriedade nos formulários de preenchimento.

### DIFF
--- a/src/modules/Entities/components/entity-field/template.php
+++ b/src/modules/Entities/components/entity-field/template.php
@@ -15,7 +15,7 @@ $this->import('
 <div v-if="propExists()" class="field" :class="[{error: hasErrors}, classes]">
     <label class="field__title" v-if="!hideLabel && !is('checkbox')" :for="propId">
         <slot>{{label || description.label}}</slot>
-        <span v-if="description.required && !hideRequired" class="required">*<?php i::_e('obrigatório') ?></span>
+        <span v-if="description.required && !hideRequired" class="required">*</span>
     </label>
     <slot name="input" >
         <?php //@todo implementar registro de tipos de campos (#1895) ?>

--- a/src/modules/Entities/components/entity-file/template.php
+++ b/src/modules/Entities/components/entity-file/template.php
@@ -17,7 +17,7 @@ $this->import('
 
     <label v-if="title" class="entity-file__title">
         {{title}}
-        <span v-if="required" class="required">*<?php i::_e('obrigatório') ?></span>
+        <span v-if="required" class="required">*</span>
     </label>
     
     <div v-if="file && hasSlot('label') && !downloadOnly" class="entity-file__label semibold">

--- a/src/modules/Entities/components/entity-location/template.php
+++ b/src/modules/Entities/components/entity-location/template.php
@@ -41,7 +41,7 @@ $this->import('
             <div class="field col-6">
                 <label class="field__title">
                     <?php i::_e('Estado')?>
-                    <span v-if="isRequired('En_Estado')" class="required">*<?php i::_e('obrigatório') ?></span>
+                    <span v-if="isRequired('En_Estado')" class="required">*</span>
                 </label>
                 <select @change="citiesList(); address()" v-model="entity.En_Estado">
                     <option v-for="state in states" :value="state.value">{{state.label}}</option>
@@ -50,7 +50,7 @@ $this->import('
             <div class="field col-6">
                 <label class="field__title">
                     <?php i::_e('Município')?>
-                    <span v-if="isRequired('En_Municipio')" class="required">*<?php i::_e('obrigatório') ?></span>
+                    <span v-if="isRequired('En_Municipio')" class="required">*</span>
                 </label>
                 <select @change="address()" v-model="entity.En_Municipio">
                     <option v-for="city in cities" :value="city">{{city}}</option>
@@ -64,7 +64,7 @@ $this->import('
             <div class="field col-6">
                     <label class="field__title">
                     <?php i::_e('Estado')?>
-                    <span v-if="isRequired('En_Estado')" class="required">*<?php i::_e('obrigatório') ?></span>
+                    <span v-if="isRequired('En_Estado')" class="required">*</span>
                 </label>
                 <input :id="propId('En_Estado')" v-model="entity.En_Estado" type="text" @change="address()" autocomplete="off">
             </div>
@@ -72,7 +72,7 @@ $this->import('
             <div class="field col-6">
                 <label class="field__title">
                     <?php i::_e('Município')?>
-                    <span v-if="isRequired('En_Municipio')" class="required">*<?php i::_e('obrigatório') ?></span>
+                    <span v-if="isRequired('En_Municipio')" class="required">*</span>
                 </label>
                 <input v-model="entity.En_Municipio" :id="propId('En_Municipio')"  type="text" @change="address()" autocomplete="off">
             </div>

--- a/src/modules/Entities/views/agent/edit-1.php
+++ b/src/modules/Entities/views/agent/edit-1.php
@@ -50,7 +50,7 @@ $this->breadcrumb = [
                 <mc-card class="feature">
                     <template #title>
                         <label><?php i::_e("Informações de Apresentação") ?></label>
-                        <p><?php i::_e("Os dados inseridos abaixo serão exibidos para todos os usuários") ?></p>
+                        <p><?php i::_e("Os campos marcados com <span style='color: red;'>*</span> são de preenchimento obrigatório. Os dados inseridos abaixo serão exibidos para todos os usuários.") ?></p>
                     </template>
                     <template #content>
                         <div class="left">
@@ -142,6 +142,7 @@ $this->breadcrumb = [
                             </div>
                         </template>
                     </mc-card>
+
                     <mc-card>
                         <template #title>
                             <label><?php i::_e("Informações públicas"); ?></label>

--- a/src/modules/Entities/views/agent/edit-2.php
+++ b/src/modules/Entities/views/agent/edit-2.php
@@ -49,7 +49,7 @@ $this->breadcrumb = [
                 <mc-card class="feature">
                     <template #title>
                         <label><?php i::_e("Informações de Apresentação") ?></label>
-                        <p><?php i::_e("Os dados inseridos abaixo serão exibidos para todos os usuários") ?></p>
+                        <p><?php i::_e("Os campos marcados com <span style='color: red;'>*</span> são de preenchimento obrigatório. Os dados inseridos abaixo serão exibidos para todos os usuários.") ?></p>
                     </template>
                     <template #content>
                         <div class="left">

--- a/src/modules/Entities/views/event/edit.php
+++ b/src/modules/Entities/views/event/edit.php
@@ -52,7 +52,7 @@ $this->breadcrumb = [
                 <mc-card class="feature">
                     <template #title>
                         <label><?php i::_e("Informações de Apresentação") ?></label>
-                        <p><?php i::_e("Os dados inseridos abaixo serão exibidos para todos os usuários") ?></p>
+                        <p><?php i::_e("Os campos marcados com <span style='color: red;'>*</span> são de preenchimento obrigatório. Os dados inseridos abaixo serão exibidos para todos os usuários.") ?></p>
                     </template>
                     <template #content>
                         <div class="left">

--- a/src/modules/Entities/views/project/edit.php
+++ b/src/modules/Entities/views/project/edit.php
@@ -51,7 +51,7 @@ $this->breadcrumb = [
                 <mc-card class="feature">
                     <template #title>
                         <label><?php i::_e("Informações de Apresentação") ?></label>
-                        <p><?php i::_e("Os dados inseridos abaixo serão exibidos para todos os usuários") ?></p>
+                        <p><?php i::_e("Os campos marcados com <span style='color: red;'>*</span> são de preenchimento obrigatório. Os dados inseridos abaixo serão exibidos para todos os usuários.") ?></p>
                     </template>
                     <template #content>
                         <div class="left">

--- a/src/modules/Entities/views/space/edit.php
+++ b/src/modules/Entities/views/space/edit.php
@@ -50,7 +50,7 @@ $this->breadcrumb = [
                 <mc-card class="feature">
                     <template #title>
                         <label class="card__title--title"><?php i::_e("Informações de Apresentação") ?></label>
-                        <p class="card__title--description"><?php i::_e("Os dados inseridos abaixo serão exibidos para todos os usuários") ?></p>
+                        <p><?php i::_e("Os campos marcados com <span style='color: red;'>*</span> são de preenchimento obrigatório. Os dados inseridos abaixo serão exibidos para todos os usuários.") ?></p>
                     </template>
                     <template #content>
                         <div class="left">


### PR DESCRIPTION
## Descrição

Foi removido o texto indicando obrigatoriedade mantendo apenas o asterisco. A mensagem do campo de informação também foi alterada.

## Validação

Desktop:
![Captura de tela de 2024-07-24 09-55-10](https://github.com/user-attachments/assets/bead4ab5-f41f-4018-a047-37c9e704bcad)

Mobile:
![Captura de tela de 2024-07-24 09-55-34](https://github.com/user-attachments/assets/0ffeaf4d-5314-40e8-8de9-ebddfefc6958)


## Issues relacionadas

Task #104 