### PR TITLE
TASK #140 [EVENTOS] Os eventos não aparecem na visualização por mapa

### DIFF
--- a/src/core/Repositories/Event.php
+++ b/src/core/Repositories/Event.php
@@ -339,11 +339,11 @@ class Event extends \MapasCulturais\Repository{
     
     function _getIdsBySQL($sql, $params = []){
         $conn = $this->_em->getConnection();
-
+    
         if($params){
-            $rs = $conn->fetchAssociative($sql, $params);
+            $rs = $conn->fetchAllAssociative($sql, $params);
         } else {
-            $rs = $conn->fetchAssociative($sql);
+            $rs = $conn->fetchAllAssociative($sql);
         }
 
         $rs = $rs ?: [];


### PR DESCRIPTION
Eu e o @Spirou1 trabalhamos em conjunto para resolver essa task.

Era bem simples, trocar um
   fetchAssociative();
por um
    fetchAllAssociative();
pois na primeira função ele apenas retornava a primeira row.

Imagem de como está agora:
![Uploading 2024-07-29_21-24.png…]()
