### PR TITLE
Padronizacao perfis destaque

### DIFF
--- a/src/modules/Components/components/entity-card/template.php
+++ b/src/modules/Components/components/entity-card/template.php
@@ -92,19 +92,19 @@ $this->import('
 		<div class="entity-card__content--terms">
 			<div v-if="areas" class="entity-card__content--terms-area">
 				<label v-if="entity.__objectType === 'opportunity'" class="area__title">
-					<?php i::_e('Áreas de interesse:') ?> ({{entity.terms.area.length}}):
+					<?php i::_e('Áreas de interesse') ?> ({{entity.terms.area.length}}):
 				</label>
 				<label v-if="entity.__objectType === 'agent' || entity.__objectType === 'space'" class="area__title">
-					<?php i::_e('Áreas de atuação:') ?> ({{entity.terms.area.length}}):
+					<?php i::_e('Áreas de atuação') ?> ({{entity.terms.area.length}}):
 				</label>
-				<p :class="['terms', entity.__objectType+'__color']"> {{areas}} </p>
+				<p :class="['terms']"> {{areas}} </p>
 			</div>
 
 			<div v-if="tags" class="entity-card__content--terms-tag">
 				<label class="tag__title">
-					<?php i::_e('Tags:') ?> ({{entity.terms.tag.length}}):
+					<?php i::_e('Tags') ?> ({{entity.terms.tag.length}}):
 				</label>
-				<p :class="['terms', entity.__objectType+'__color']"> {{tags}} </p>
+				<p :class="'terms'"> {{tags}} </p>
 			</div>
 
 			<div v-if="linguagens" class="entity-card__content--terms-linguagem">

--- a/src/modules/Components/components/occurrence-card/template.php
+++ b/src/modules/Components/components/occurrence-card/template.php
@@ -60,17 +60,17 @@ $this->import('
             </div>
         </div>
         <div class="entity-card__content--terms">
-            <div v-if="tags" class="entity-card__content--terms-tag">
+            <div v-if="tags" class="-tag">
                 <label class="tag__title">
-                    <?php i::_e('Tags:') ?> ({{event.terms.tag.length}}):
+                    <?php i::_e('Tags') ?> ({{event.terms.tag.length}}):
                 </label>
-                <p :class="['terms', 'event__color']"> {{tags}} </p>
+                <p :class="'terms'"> {{tags}} </p>
             </div>
             <div v-if="linguagens" class="entity-card__content--terms-linguagem">
                 <label class="linguagem__title">
-                    <?php i::_e('linguagens:') ?> ({{event.terms.linguagem.length}}):
+                    <?php i::_e('linguagens') ?> ({{event.terms.linguagem.length}}):
                 </label>
-                <p :class="['terms', 'event__color']"> {{linguagens}} </p>
+                <p :class="'terms'"> {{linguagens}} </p>
             </div>
         </div>
     </div>

--- a/src/modules/Entities/components/entity-map/template.php
+++ b/src/modules/Entities/components/entity-map/template.php
@@ -11,7 +11,7 @@ $this->import('
 ?>
 
 <?php $this->applyTemplateHook('entity-map','before'); ?>
-<mc-map :center="entity.location" v-if="entity.endereco">
+<mc-map v-if="entity.endereco" :center="entity.location">
     <mc-map-marker :entity="entity" :draggable="editable" @moved="change($event)"></mc-map-marker>
 </mc-map>
 <?php $this->applyTemplateHook('entity-map','after'); ?>

--- a/src/modules/Entities/components/entity-map/template.php
+++ b/src/modules/Entities/components/entity-map/template.php
@@ -11,7 +11,7 @@ $this->import('
 ?>
 
 <?php $this->applyTemplateHook('entity-map','before'); ?>
-<mc-map :center="entity.location">
+<mc-map v-if="entity.endereco" :center="entity.location">
     <mc-map-marker :entity="entity" :draggable="editable" @moved="change($event)"></mc-map-marker>
 </mc-map>
 <?php $this->applyTemplateHook('entity-map','after'); ?>

--- a/src/modules/Entities/components/entity-map/template.php
+++ b/src/modules/Entities/components/entity-map/template.php
@@ -11,7 +11,7 @@ $this->import('
 ?>
 
 <?php $this->applyTemplateHook('entity-map','before'); ?>
-<mc-map v-if="entity.endereco" :center="entity.location">
+<mc-map :center="entity.location" v-if="entity.endereco">
     <mc-map-marker :entity="entity" :draggable="editable" @moved="change($event)"></mc-map-marker>
 </mc-map>
 <?php $this->applyTemplateHook('entity-map','after'); ?>

--- a/src/modules/Entities/components/entity-status/template.php
+++ b/src/modules/Entities/components/entity-status/template.php
@@ -61,7 +61,7 @@ $this->import('
         <template v-if="entity.__objectType == 'project'">
             <span v-if="entity.status == 0">
                 <strong><?= i::__('Este projeto está em rascunho.'); ?></strong>
-                <?= i::__('Você Você precisa <strong>publicar</strong> para exibir para todas as pessoas.') ?>
+                <?= i::__('Você precisa <strong>publicar</strong> para exibir para todas as pessoas.') ?>
             </span>
             <span v-if="entity.status == -10">
                 <strong><?= i::__('Este projeto está na lixeira.'); ?></strong>
@@ -76,7 +76,7 @@ $this->import('
         <template v-if="entity.__objectType == 'opportunity'">
             <span v-if="entity.status == 0">
                 <strong><?= i::__('Este oportunidade está em rascunho.'); ?></strong>
-                <?= i::__('Você Você precisa <strong>publicar</strong> para exibir para todas as pessoas.') ?>
+                <?= i::__('Você precisa <strong>publicar</strong> para exibir para todas as pessoas.') ?>
             </span>
             <span v-if="entity.status == -10">
                 <strong><?= i::__('Este oportunidade está na lixeira.'); ?></strong>

--- a/src/modules/Entities/components/entity-terms/script.js
+++ b/src/modules/Entities/components/entity-terms/script.js
@@ -115,14 +115,29 @@ app.component('entity-terms', {
 
 
         addTerm(term) {
-            if (this.entity.terms[this.taxonomy].indexOf(term) < 0) {
-                this.entity.terms[this.taxonomy].push(term);
+            if(this.spaceCheck(term)) {
+                if (this.entity.terms[this.taxonomy].indexOf(term) < 0) {
+                    this.entity.terms[this.taxonomy].push(term);
+                    
+                }
+    
+                if (this.terms.indexOf(term) < 0) {
+                   this.terms.push(term);
+                }
             }
+        },
 
-            if (this.terms.indexOf(term) < 0) {
-                this.terms.push(term);
+        spaceCheck(term) {
+            if(this.taxonomy == "tag") {
+                let tam = term.length;
+                for (let i = 0; i < tam; i++) {
+                    if (term[i] != " ") {
+                        return true;
+                    }
+                }
+                return false;
             }
-           
+            return true;
         },
 
         taxomyExists() {

--- a/src/modules/Entities/components/entity-terms/template.php
+++ b/src/modules/Entities/components/entity-terms/template.php
@@ -16,7 +16,6 @@ $this->import('
 <div v-if="taxomyExists() && (editable || entity.terms?.[taxonomy].length > 0)" :class="['entity-terms', classes, error]">
     <div class="entity-terms__header">
         <mc-title tag="h4" :short-length="0" size="medium" class="bold">{{title ?? taxonomy}}</mc-title>
-        <span class="entity-terms__required" style="color: red">*</span>
     </div>
  
     <mc-popover v-if="allowInsert && editable" openside="down-right"  @open="loadTerms()" :title="popoverTitle">

--- a/src/modules/Entities/views/project/single.php
+++ b/src/modules/Entities/views/project/single.php
@@ -72,7 +72,7 @@ $this->breadcrumb = [
 
                                 <div v-if="entity.emailPublico" class="additional-info__item">
                                     <p class="additional-info__item__title"><?php i::_e("email:"); ?></p>
-                                    <p class="additional-info__item__content">{{entity.emailPublico}}</p>
+                                    <p>{{entity.emailPublico}}</p>
                                 </div>
                             </div>
                             <div v-if="entity.longDescription!=null" class="col-12">

--- a/src/modules/Home/components/home-entities/template.php
+++ b/src/modules/Home/components/home-entities/template.php
@@ -31,9 +31,9 @@ $this->import('
                                 <mc-icon name="opportunity"></mc-icon>
                             </div>                        
                             <div class="card__left--content-title">
-                                    <label class="title">
+                                    <h3 class="title">
                                         <?= i::__('Oportunidades') ?>
-                                    </label>
+                                    </h3>
                             </div>
                         </div>
                         <div class="card__left--img">
@@ -58,9 +58,9 @@ $this->import('
                                 <mc-icon name="event"></mc-icon>
                             </div>                        
                             <div class="card__left--content-title">
-                                <label class="title">
+                                <h3 class="title">
                                     <?= i::__('Eventos') ?>
-                                </label>
+                                </h3>
                             </div>
                         </div>
                         <div class="card__left--img">
@@ -85,9 +85,9 @@ $this->import('
                                 <mc-icon name="space"></mc-icon>
                             </div>                        
                             <div class="card__left--content-title">
-                                <label class="title">
+                                <h3 class="title">
                                     <?= i::__('Espaços') ?>
-                                </label>
+                                </h3>
                             </div>
                         </div>
                         <div class="card__left--img">
@@ -112,9 +112,9 @@ $this->import('
                                 <mc-icon name="agent-2"></mc-icon>
                             </div>                        
                             <div class="card__left--content-title">
-                                <label class="title">
+                                <h3 class="title">
                                     <?= i::__('Agentes') ?>
-                                </label>
+                                </h3>
                             </div>
                         </div>
                         <div class="card__left--img">
@@ -139,9 +139,9 @@ $this->import('
                                 <mc-icon name="project"></mc-icon>
                             </div>                        
                             <div class="card__left--content-title">
-                                <label class="title">
+                                <h3 class="title">
                                     <?= i::__('Projetos') ?>
-                                </label>
+                                </h3>
                             </div>
                         </div>
                         <div class="card__left--img">

--- a/src/modules/Home/components/home-entities/template.php
+++ b/src/modules/Home/components/home-entities/template.php
@@ -25,19 +25,21 @@ $this->import('
         <div class="home-entities__content--cards">
             <div v-if="global.enabledEntities.opportunities" class="card">
                 <div class="card__left">
-                    <div class="card__left--content">
-                        <div class="card__left--content-icon opportunity__background">
-                            <mc-icon name="opportunity"></mc-icon>
-                        </div>                        
-                        <div class="card__left--content-title">
-                            <label class="title">
-                                <?= i::__('Oportunidades') ?>
-                            </label>
+                    <mc-link route="search/opportunities">
+                        <div class="card__left--content">
+                            <div class="card__left--content-icon opportunity__background">
+                                <mc-icon name="opportunity"></mc-icon>
+                            </div>                        
+                            <div class="card__left--content-title">
+                                    <label class="title">
+                                        <?= i::__('Oportunidades') ?>
+                                    </label>
+                            </div>
                         </div>
-                    </div>
-                    <div class="card__left--img">
-                        <img src="<?php $this->asset($app->config['module.home']['home-opportunities']) ?>" />
-                    </div>
+                        <div class="card__left--img">
+                            <img src="<?php $this->asset($app->config['module.home']['home-opportunities']) ?>" />
+                        </div>
+                    </mc-link>
                 </div>
                 <div class="card__right">
                     <p><?= $this->text('opportunities', i::__('Faça a sua inscrição ou acesse o resultado de diversas convocatórias como editais, oficinas, prêmios e concursos. Você também pode criar o seu próprio formulário e divulgar uma oportunidade para outros agentes culturais.')) ?></p>
@@ -50,19 +52,21 @@ $this->import('
 
             <div v-if="global.enabledEntities.events" class="card">
                 <div class="card__left">
-                    <div class="card__left--content">
-                        <div class="card__left--content-icon event__background">
-                            <mc-icon name="event"></mc-icon>
-                        </div>                        
-                        <div class="card__left--content-title">
-                            <label class="title">
-                                <?= i::__('Eventos') ?>
-                            </label>
+                    <mc-link route="search/events">
+                        <div class="card__left--content">
+                            <div class="card__left--content-icon event__background">
+                                <mc-icon name="event"></mc-icon>
+                            </div>                        
+                            <div class="card__left--content-title">
+                                <label class="title">
+                                    <?= i::__('Eventos') ?>
+                                </label>
+                            </div>
                         </div>
-                    </div>
-                    <div class="card__left--img">
-                        <img src="<?php $this->asset($app->config['module.home']['home-events']) ?>" />
-                    </div>
+                        <div class="card__left--img">
+                            <img src="<?php $this->asset($app->config['module.home']['home-events']) ?>" />
+                        </div>
+                    </mc-link>
                 </div>
                 <div class="card__right">
                     <p><?= $this->text('events', i::__('Você pode pesquisar eventos culturais nos campos de busca combinada. Como usuário cadastrado, você pode incluir seus eventos na plataforma e divulgá-los gratuitamente. (Mais uma linha aqui pra fechar cinco linhas)')) ?></p>
@@ -75,19 +79,21 @@ $this->import('
 
             <div v-if="global.enabledEntities.spaces" class="card">
                 <div class="card__left">
-                    <div class="card__left--content">
-                        <div class="card__left--content-icon space__background">
-                            <mc-icon name="space"></mc-icon>
-                        </div>                        
-                        <div class="card__left--content-title">
-                            <label class="title">
-                                <?= i::__('Espaços') ?>
-                            </label>
+                    <mc-link route="search/spaces">
+                        <div class="card__left--content">
+                            <div class="card__left--content-icon space__background">
+                                <mc-icon name="space"></mc-icon>
+                            </div>                        
+                            <div class="card__left--content-title">
+                                <label class="title">
+                                    <?= i::__('Espaços') ?>
+                                </label>
+                            </div>
                         </div>
-                    </div>
-                    <div class="card__left--img">
-                        <img src="<?php $this->asset($app->config['module.home']['home-spaces']) ?>" />
-                    </div>
+                        <div class="card__left--img">
+                            <img src="<?php $this->asset($app->config['module.home']['home-spaces']) ?>" />
+                        </div>
+                    </mc-link>
                 </div>
                 <div class="card__right">
                     <p><?= $this->text('spaces', i::__('Procure por espaços culturais incluídos na plataforma, acessando os campos de busca combinada que ajudam na precisão de sua pesquisa. Cadastre também os espaços onde desenvolve suas atividades artísticas e culturais.')) ?></p>
@@ -100,19 +106,21 @@ $this->import('
 
             <div v-if="global.enabledEntities.agents" class="card">
                 <div class="card__left">
-                    <div class="card__left--content">
-                        <div class="card__left--content-icon agent__background">
-                            <mc-icon name="agent-2"></mc-icon>
-                        </div>                        
-                        <div class="card__left--content-title">
-                            <label class="title">
-                                <?= i::__('Agentes') ?>
-                            </label>
+                    <mc-link route="search/agents"> 
+                        <div class="card__left--content">
+                            <div class="card__left--content-icon agent__background">
+                                <mc-icon name="agent-2"></mc-icon>
+                            </div>                        
+                            <div class="card__left--content-title">
+                                <label class="title">
+                                    <?= i::__('Agentes') ?>
+                                </label>
+                            </div>
                         </div>
-                    </div>
-                    <div class="card__left--img">
-                        <img src="<?php $this->asset($app->config['module.home']['home-agents']) ?>" />
-                    </div>
+                        <div class="card__left--img">
+                            <img src="<?php $this->asset($app->config['module.home']['home-agents']) ?>" />
+                        </div>
+                    </mc-link>
                 </div>
                 <div class="card__right">
                     <p><?= $this->text('agents', i::__('Neste espaço, estão registrados artistas, gestores e produtores; uma rede de atores envolvidos na cena cultural da região. Você pode cadastrar um ou mais agentes (grupos, coletivos, bandas instituições, empresas, etc.), (...)')) ?></p>
@@ -125,19 +133,21 @@ $this->import('
 
             <div v-if="global.enabledEntities.projects" class="card">
                 <div class="card__left">
-                    <div class="card__left--content">
-                        <div class="card__left--content-icon project__background">
-                            <mc-icon name="project"></mc-icon>
-                        </div>                        
-                        <div class="card__left--content-title">
-                            <label class="title">
-                                <?= i::__('Projetos') ?>
-                            </label>
+                    <mc-link route="search/projects">
+                        <div class="card__left--content">
+                            <div class="card__left--content-icon project__background">
+                                <mc-icon name="project"></mc-icon>
+                            </div>                        
+                            <div class="card__left--content-title">
+                                <label class="title">
+                                    <?= i::__('Projetos') ?>
+                                </label>
+                            </div>
                         </div>
-                    </div>
-                    <div class="card__left--img">
-                        <img src="<?php $this->asset($app->config['module.home']['home-projects']) ?>" />
-                    </div>
+                        <div class="card__left--img">
+                            <img src="<?php $this->asset($app->config['module.home']['home-projects']) ?>" />
+                        </div>
+                    </mc-link>
                 </div>
                 <div class="card__right">
                     <p><?= $this->text('projects', i::__('Aqui você encontra leis de fomento, mostras, convocatórias e editais criados, além de diversas iniciativas cadastradas pelos usuários da plataforma.')) ?></p>

--- a/src/themes/BaseV2/assets-src/sass/2.components/_entity-card.scss
+++ b/src/themes/BaseV2/assets-src/sass/2.components/_entity-card.scss
@@ -386,6 +386,9 @@
 	}
 
 	&.portrait {
+		display: flex;
+    	flex-direction: column;
+    	justify-content: space-between;
 		.entity-card__header {
 			&.user-details {
 				flex-direction: column;

--- a/src/themes/BaseV2/assets-src/sass/2.components/_home-feature.scss
+++ b/src/themes/BaseV2/assets-src/sass/2.components/_home-feature.scss
@@ -106,9 +106,10 @@
 
 				&__viewport {
 					ol {
-						li{
+						li{	
 							
 							justify-content: flex-start;
+							align-items: stretch;
 							padding: 0 size(40) 0 0;
 
 							@media (max-width: size(600)) {
@@ -130,7 +131,7 @@
 				}
 
 				&__track {
-					align-items: flex-start;
+					align-items: stretch;
 				}
 			}
 


### PR DESCRIPTION
## Descrição

Os perfis de destaque da home agora possuem o mesmo tamanho independente do conteúdo.

## Validação
![image](https://github.com/user-attachments/assets/f56f375c-e9e2-4868-b32c-25947aa9b1d4)

## Issues relacionadas
Mapas #67 - [HOME] Padronizar alturas de perfis em destaque