### PR TITLE
Feature/filtro incompleto mobile

### DIFF
--- a/src/modules/Search/components/search-filter-event/template.php
+++ b/src/modules/Search/components/search-filter-event/template.php
@@ -22,6 +22,10 @@ $this->import('
         <div class="field">
             <label> <?php i::_e('Eventos acontecendo') ?></label>
             <div class="datepicker">
+                <div class="filter-btn">
+                    <button @click="prevInterval()" class="button button--rounded button--outline"> <mc-icon name="arrow-left"></mc-icon> </button>
+                    <button @click="nextInterval()" class="button button--rounded button--outline"> <mc-icon name="arrow-right"></mc-icon> </button>
+                </div>
                 <datepicker 
                     :locale="locale" 
                     :weekStart="0"
@@ -30,11 +34,8 @@ $this->import('
                     :format="dateFormat"
                     :presetRanges="presetRanges" 
                     :dayNames="['Dom', 'Seg', 'Ter', 'Qua', 'Qui', 'Sex', 'Sab']"
-                    range multiCalendars multiCalendarsSolo autoApply utc></datepicker>
-                <div class="filter-btn">
-                    <button @click="prevInterval()" class="button button--rounded button--outline"> <mc-icon name="arrow-left"></mc-icon> </button>
-                    <button @click="nextInterval()" class="button button--rounded button--outline"> <mc-icon name="arrow-right"></mc-icon> </button>
-                </div>
+                    range multiCalendars multiCalendarsSolo autoApply utc>
+                </datepicker>
             </div>
         </div>
         <div class="field">

--- a/src/modules/Search/components/search-filter/template.php
+++ b/src/modules/Search/components/search-filter/template.php
@@ -25,9 +25,10 @@ $this->import('
             </button>
         </div>
         <div :class="['search-filter__filter', {'show': showMenu}]">
-            <div class="content">
-                <a href="#main-app" class="search-filter__filter--close button button--icon" @click="toggleFilter()"><?= i::_e('Fechar') ?> <mc-icon name="close"></mc-icon></a>
-                <slot><?= i::__('Filtrar'); ?></slot>
+            <div class="content button--filter--bottom">
+            <slot><?= i::__('Filtrar'); ?></slot>
+            <a href="#main-app" class="button--primary button--large button--icon button button--icon" @click="toggleFilter()"><?= i::_e('Aplicar Filtros') ?></a>
+                
             </div>
         </div>
     </div>

--- a/src/themes/BaseV2/assets-src/sass/2.components/_button.scss
+++ b/src/themes/BaseV2/assets-src/sass/2.components/_button.scss
@@ -347,4 +347,23 @@
             color: var(--mc-warning-500);
         }
     }
+    @media (max-width: 900px){
+        &--filter--bottom{
+            top: -35px;
+            position: relative;
+            .button--primary.button--large{
+                position: relative;
+                top: 30px;
+            }
+        }
+    }
+    @media (min-width: 901px){
+        &--filter--bottom{
+            top: 0px;
+            position: relative;
+            .button--primary.button--large{
+                display: none;
+            }
+        }
+    }
 }

--- a/src/themes/BaseV2/assets-src/sass/2.components/_datepicker.scss
+++ b/src/themes/BaseV2/assets-src/sass/2.components/_datepicker.scss
@@ -152,9 +152,9 @@
         }
 
         // Lista lateral de ranges
-        &__preset_ranges {
-            display: none;
-        }
+        // &__preset_ranges {
+        //     display: none;
+        // }
 
         // Parte dos calendários
         &__flex_display {
@@ -207,6 +207,14 @@
                     width: size(35);
                 }
             }
+        }
+    }
+    @media (max-width: 600px) {
+        &__menu_content_wrapper {
+            flex-direction: column;
+        }
+        &__preset_ranges {
+            border-bottom: 2px solid rgb(26, 25, 25);
         }
     }
 }


### PR DESCRIPTION
TASK #136 

Coloquei opção de filtragem com preset (filtrar por "esse mês", "2024", "hoje") nas versões mobile.

Obs: Na foto abaixo não da pra ver, mas é só arrastar para baixo para ver o calendário completo caso o usuário prefira filtrar pelos dias específicos

![Screenshot from 2024-08-15 10-04-33](https://github.com/user-attachments/assets/44cab1b0-2081-4fe7-910e-42a54abbea30)
