### PR TITLE
Indicar publicacao painel controle

### DIFF
--- a/src/modules/Components/components/entity-card/template.php
+++ b/src/modules/Components/components/entity-card/template.php
@@ -92,19 +92,19 @@ $this->import('
 		<div class="entity-card__content--terms">
 			<div v-if="areas" class="entity-card__content--terms-area">
 				<label v-if="entity.__objectType === 'opportunity'" class="area__title">
-					<?php i::_e('Áreas de interesse:') ?> ({{entity.terms.area.length}}):
+					<?php i::_e('Áreas de interesse') ?> ({{entity.terms.area.length}}):
 				</label>
 				<label v-if="entity.__objectType === 'agent' || entity.__objectType === 'space'" class="area__title">
-					<?php i::_e('Áreas de atuação:') ?> ({{entity.terms.area.length}}):
+					<?php i::_e('Áreas de atuação') ?> ({{entity.terms.area.length}}):
 				</label>
-				<p :class="['terms', entity.__objectType+'__color']"> {{areas}} </p>
+				<p :class="['terms']"> {{areas}} </p>
 			</div>
 
 			<div v-if="tags" class="entity-card__content--terms-tag">
 				<label class="tag__title">
-					<?php i::_e('Tags:') ?> ({{entity.terms.tag.length}}):
+					<?php i::_e('Tags') ?> ({{entity.terms.tag.length}}):
 				</label>
-				<p :class="['terms', entity.__objectType+'__color']"> {{tags}} </p>
+				<p :class="'terms'"> {{tags}} </p>
 			</div>
 
 			<div v-if="linguagens" class="entity-card__content--terms-linguagem">

--- a/src/modules/Components/components/occurrence-card/template.php
+++ b/src/modules/Components/components/occurrence-card/template.php
@@ -60,17 +60,17 @@ $this->import('
             </div>
         </div>
         <div class="entity-card__content--terms">
-            <div v-if="tags" class="entity-card__content--terms-tag">
+            <div v-if="tags" class="-tag">
                 <label class="tag__title">
-                    <?php i::_e('Tags:') ?> ({{event.terms.tag.length}}):
+                    <?php i::_e('Tags') ?> ({{event.terms.tag.length}}):
                 </label>
-                <p :class="['terms', 'event__color']"> {{tags}} </p>
+                <p :class="'terms'"> {{tags}} </p>
             </div>
             <div v-if="linguagens" class="entity-card__content--terms-linguagem">
                 <label class="linguagem__title">
-                    <?php i::_e('linguagens:') ?> ({{event.terms.linguagem.length}}):
+                    <?php i::_e('linguagens') ?> ({{event.terms.linguagem.length}}):
                 </label>
-                <p :class="['terms', 'event__color']"> {{linguagens}} </p>
+                <p :class="'terms'"> {{linguagens}} </p>
             </div>
         </div>
     </div>

--- a/src/modules/Entities/components/entity-map/template.php
+++ b/src/modules/Entities/components/entity-map/template.php
@@ -11,7 +11,7 @@ $this->import('
 ?>
 
 <?php $this->applyTemplateHook('entity-map','before'); ?>
-<mc-map :center="entity.location" v-if="entity.endereco">
+<mc-map v-if="entity.endereco" :center="entity.location">
     <mc-map-marker :entity="entity" :draggable="editable" @moved="change($event)"></mc-map-marker>
 </mc-map>
 <?php $this->applyTemplateHook('entity-map','after'); ?>

--- a/src/modules/Entities/components/entity-map/template.php
+++ b/src/modules/Entities/components/entity-map/template.php
@@ -11,7 +11,7 @@ $this->import('
 ?>
 
 <?php $this->applyTemplateHook('entity-map','before'); ?>
-<mc-map :center="entity.location">
+<mc-map v-if="entity.endereco" :center="entity.location">
     <mc-map-marker :entity="entity" :draggable="editable" @moved="change($event)"></mc-map-marker>
 </mc-map>
 <?php $this->applyTemplateHook('entity-map','after'); ?>

--- a/src/modules/Entities/components/entity-map/template.php
+++ b/src/modules/Entities/components/entity-map/template.php
@@ -11,7 +11,7 @@ $this->import('
 ?>
 
 <?php $this->applyTemplateHook('entity-map','before'); ?>
-<mc-map v-if="entity.endereco" :center="entity.location">
+<mc-map :center="entity.location" v-if="entity.endereco">
     <mc-map-marker :entity="entity" :draggable="editable" @moved="change($event)"></mc-map-marker>
 </mc-map>
 <?php $this->applyTemplateHook('entity-map','after'); ?>

--- a/src/modules/Entities/components/entity-terms/script.js
+++ b/src/modules/Entities/components/entity-terms/script.js
@@ -115,14 +115,29 @@ app.component('entity-terms', {
 
 
         addTerm(term) {
-            if (this.entity.terms[this.taxonomy].indexOf(term) < 0) {
-                this.entity.terms[this.taxonomy].push(term);
+            if(this.spaceCheck(term)) {
+                if (this.entity.terms[this.taxonomy].indexOf(term) < 0) {
+                    this.entity.terms[this.taxonomy].push(term);
+                    
+                }
+    
+                if (this.terms.indexOf(term) < 0) {
+                   this.terms.push(term);
+                }
             }
+        },
 
-            if (this.terms.indexOf(term) < 0) {
-                this.terms.push(term);
+        spaceCheck(term) {
+            if(this.taxonomy == "tag") {
+                let tam = term.length;
+                for (let i = 0; i < tam; i++) {
+                    if (term[i] != " ") {
+                        return true;
+                    }
+                }
+                return false;
             }
-           
+            return true;
         },
 
         taxomyExists() {

--- a/src/modules/Entities/components/entity-terms/template.php
+++ b/src/modules/Entities/components/entity-terms/template.php
@@ -16,7 +16,6 @@ $this->import('
 <div v-if="taxomyExists() && (editable || entity.terms?.[taxonomy].length > 0)" :class="['entity-terms', classes, error]">
     <div class="entity-terms__header">
         <mc-title tag="h4" :short-length="0" size="medium" class="bold">{{title ?? taxonomy}}</mc-title>
-        <span class="entity-terms__required" style="color: red">*</span>
     </div>
  
     <mc-popover v-if="allowInsert && editable" openside="down-right"  @open="loadTerms()" :title="popoverTitle">

--- a/src/modules/Entities/views/project/single.php
+++ b/src/modules/Entities/views/project/single.php
@@ -72,7 +72,7 @@ $this->breadcrumb = [
 
                                 <div v-if="entity.emailPublico" class="additional-info__item">
                                     <p class="additional-info__item__title"><?php i::_e("email:"); ?></p>
-                                    <p class="additional-info__item__content">{{entity.emailPublico}}</p>
+                                    <p>{{entity.emailPublico}}</p>
                                 </div>
                             </div>
                             <div v-if="entity.longDescription!=null" class="col-12">

--- a/src/modules/Panel/components/panel--entities-summary/script.js
+++ b/src/modules/Panel/components/panel--entities-summary/script.js
@@ -26,23 +26,23 @@ app.component('panel--entities-summary', {
     data() {
         return {
             spaces: {
-                title: $MAPAS.config.entitySummary.spaces > 1 ? __('espaços', 'panel--entities-summary') : __('espaço', 'panel--entities-summary'),
+                title: $MAPAS.config.entitySummary.spaces > 1 ? __('publicados', 'panel--entities-summary') : __('publicado', 'panel--entities-summary'),
                 count: $MAPAS.config.entitySummary.spaces,
             },
             agents: {
-                title: $MAPAS.config.entitySummary.agents > 1 ? __('agentes', 'panel--entities-summary') : __('agente', 'panel--entities-summary'),
+                title: $MAPAS.config.entitySummary.agents > 1 ? __('publicados', 'panel--entities-summary') : __('publicado', 'panel--entities-summary'),
                 count: $MAPAS.config.entitySummary.agents,
             },
             events: {
-                title: $MAPAS.config.entitySummary.events > 1 ? __('eventos', 'panel--entities-summary') : __('evento', 'panel--entities-summary'),
+                title: $MAPAS.config.entitySummary.events > 1 ? __('publicados', 'panel--entities-summary') : __('publicado', 'panel--entities-summary'),
                 count: $MAPAS.config.entitySummary.events,
             },
             projects: {
-                title: $MAPAS.config.entitySummary.projects > 1 ? __('projetos', 'panel--entities-summary') : __('projeto', 'panel--entities-summary'),
+                title: $MAPAS.config.entitySummary.projects > 1 ? __('publicados', 'panel--entities-summary') : __('publicado', 'panel--entities-summary'),
                 count: $MAPAS.config.entitySummary.projects,
             },
             opportunities: {
-                title: $MAPAS.config.entitySummary.opportunities > 1 ? __('oportunidades', 'panel--entities-summary') : __('oportunidade', 'panel--entities-summary'),
+                title: $MAPAS.config.entitySummary.opportunities > 1 ? __('publicadas', 'panel--entities-summary') : __('publicada', 'panel--entities-summary'),
                 count: $MAPAS.config.entitySummary.opportunities,
             },
         }


### PR DESCRIPTION
## Descrição

Mudança na indicação do painel de controle para publicado(s) a fim de deixar mais claro para o usuário que o número de entidades mostradas não corresponde ao total.

## Validação

![image](https://github.com/user-attachments/assets/0733eae5-a75b-44ac-a5a6-d6bccfb2e04b)


## Issues relacionadas

Mapas #129 - [EVENTOS] Número de eventos indicados no painel de controle não corresponde à realidade