### PR TITLE
Padronizacao eventos gratuitos

### DIFF
--- a/src/modules/Entities/components/create-occurrence/script.js
+++ b/src/modules/Entities/components/create-occurrence/script.js
@@ -184,6 +184,12 @@ app.component('create-occurrence', {
             let floatNum = intNum.slice(0, -2) + "." + intNum.slice(-2);
             this.price = this.moneyMask(floatNum);
         },
+        checkPrice() {
+            if(this.price == "R$ 0,00") {
+                return null;
+            }
+            return this.price;
+        },
 
         // Criação da ocorrência
         create(modal) {
@@ -235,7 +241,7 @@ app.component('create-occurrence', {
             }      
 
             this.newOccurrence['description'] = this.description ?? '';
-            this.newOccurrence['price'] = this.free ? __('Gratuito', 'create-occurrence') : this.price;
+            this.newOccurrence['price'] = this.free ? __('Gratuito', 'create-occurrence') : this.checkPrice();
             this.newOccurrence['priceInfo'] = this.priceInfo ?? '';
             
             this.newOccurrence.save().then(() => {

--- a/src/modules/Entities/components/create-occurrence/script.js
+++ b/src/modules/Entities/components/create-occurrence/script.js
@@ -185,9 +185,8 @@ app.component('create-occurrence', {
             this.price = this.moneyMask(floatNum);
         },
         checkPrice() {
-            if(this.price == "R$ 0,00") {
+            if(this.price == "R$ 0,00") 
                 return null;
-            }
             return this.price;
         },
 


### PR DESCRIPTION
## Descrição

Agora caso alguém marque o evento como não gratuito não é mais possível criar uma ocorrência com o preço R$ 0,00. Há um erro e é pedido que a pessoa insira um preço.

## Validação

![image](https://github.com/user-attachments/assets/7b619aef-1009-4bd9-ab59-8133d1f2164a)


## Issues relacionadas

Mapas #125 - [EVENTOS] Despadronização de eventos gratuitos.