### PR TITLE
Feat/arruma cypress cherry pick

### DIFF
--- a/src/cypress/commands/checkFilterCount.js
+++ b/src/cypress/commands/checkFilterCount.js
@@ -6,27 +6,27 @@ function checkFilterCount() {
         let resultsType = resultsTextArray[1];
         const resultsCountPerPage = resultsCount < countPerPage ? resultsCount : countPerPage;
 
-    	switch (resultsType) {
-        	case "Oportunidades":
-        	    cy.get('.upper').should("have.length", resultsCountPerPage);
-        	    cy.wait(1000);
-        	    cy.contains(resultsCount + " Oportunidades encontradas");
-			
-        	    break;
-			
-        	case "Projetos":
-        		cy.get('.upper').should("have.length", resultsCountPerPage);
-        		cy.wait(1000);
-        		cy.contains(resultsCount + " Projetos encontrados");
-			
-        	    break;
-			
-        	case "Espaços":
-        	    cy.get('.upper').should("have.length", resultsCountPerPage);
-        	    cy.wait(1000);
-        	    cy.contains(resultsCount + " Espaços encontrados");
-			
-        	    break;
+                switch (resultsType) {
+                        case "Oportunidades":
+                                cy.get('.upper').should("have.length", resultsCountPerPage);
+                                cy.wait(1000);
+                                cy.contains(resultsCount + " Oportunidades encontradas");
+                                
+                                break;
+                        
+                        case "Projetos":
+                                cy.get('.upper').should("have.length", resultsCountPerPage);
+                                cy.wait(1000);
+                                cy.contains(resultsCount + " Projetos encontrados");
+        
+                                break;
+                        
+                        case "Espaços":
+                                cy.get('.upper').should("have.length", resultsCountPerPage);
+                                cy.wait(1000);
+                                cy.contains(resultsCount + " Espaços encontrados");
+                
+                                break;
 
         	default:
         	    cy.log("checkFilterCount(): tipo inválido");

--- a/src/cypress/e2e/agentesPage/index.cy.js
+++ b/src/cypress/e2e/agentesPage/index.cy.js
@@ -53,14 +53,20 @@ describe("Agents Page", () => {
         cy.get(":nth-child(2) > select").select(2);
         cy.contains("Agente Coletivo");
         cy.wait(1000);
-
+        
+        //Pega o número de agentes totais depois de aplicar o filtro para 'Agente Coletivo'
         cy.get(".foundResults").invoke('text').then((text) => {
-            // Extraia o número da string
-            expectedCount = parseInt(text.match(/\d+/)[0], 10);
-            
-            // Agora, verifique se o número de agentes do tipo coletivo encontrados é igual ao esperado
-            cy.get('.entity-card__header.without-labels > .user-details > .user-info > a > .mc-title').should('have.length', expectedCount)
-            cy.contains(expectedCount + " Agentes encontrados")
+            // Extraia o número da string e converte para int
+            const expectedCount = parseInt(text.match(/\d+/)[0], 10);
+
+            // Pega o número de agentes totais na tabela de cima
+            cy.get(".entity-cards-cards__number").eq(2).invoke('text').then((text2) => {
+                          
+              // Converte o texto para int
+              const elementNumber = parseInt(text2, 10);
+              // Compara para ver se os números são iguais
+              expect(elementNumber).to.equal(expectedCount);
+            });
         });
 
         cy.get(":nth-child(2) > select").select(1);
@@ -71,10 +77,17 @@ describe("Agents Page", () => {
             // Extraia o número da string
             expectedCount = parseInt(text.match(/\d+/)[0], 10);
             
-            // Agora, verifique se o número de agentes do tipo individual encontrados é igual ao esperado
-            cy.get('.entity-card__header.without-labels > .user-details > .user-info > a > .mc-title').should('have.length', expectedCount)
-            cy.contains(expectedCount + " Agentes encontrados");
-        });
+            // Pega o número de agentes totais na tabela de cima
+            cy.get(".entity-cards-cards__number").eq(1).invoke('text').then((text2) => {
+
+          
+                // Converte o texto para int
+                const elementNumber = parseInt(text2, 10);
+                // Compara para ver se os números são iguais
+                expect(elementNumber).to.equal(expectedCount);
+              });
+          });
+
     });
 
     it("Garante que os filtros por área de atuação funcionam", () => {

--- a/src/cypress/e2e/homepage/full.cy.js
+++ b/src/cypress/e2e/homepage/full.cy.js
@@ -46,20 +46,19 @@ describe("Homepage", () => {
         cy.get(".carousel__prev").click();
     });
 
-    it("Acessa o navbar e o botão \"Acessar\" dos cards da seção \"Em destaque\"", () => {
-        cy.get(".agents > a > span").click();
-        cy.wait(1000);
-        cy.get(".carousel__slide--active > .entity-card > .entity-card__footer > .entity-card__footer--action > .button").click();
-        cy.url().should("include", "/agente/");
+    it("Acessa o navbar e o botão \"Acessar\" dos cards da seção \"Em desteaque\"", () => {
+        cy.contains("Acessar").eq(0).click();
+        cy.wait(2000);
+        cy.url().should("include", "/agente/27/#info");
         cy.contains("Anne Elisa");
         backHomepage();
 
         cy.get(".agents > a > span").click();
         cy.wait(1000);
         cy.get('.carousel__next').click();
-        cy.get('[style="width: 31.25%; order: 3;"] > .entity-card > .entity-card__footer > .entity-card__footer--action > .button').click();
-        cy.url().should("include", "/agente/");
-        cy.contains("a", "https://pt.wikipedia.org/wiki/Cleodon_Silva");
+        cy.get('[style="width: 31.25%; order: 2;"] > .entity-card > .entity-card__footer > .entity-card__footer--action > .button').click();
+        cy.url().should("include", "/agente/16/#info");
+        cy.contains("Universidade de Brasília");
         backHomepage();
         
         /*

--- a/src/cypress/e2e/loginPage/index.cy.js
+++ b/src/cypress/e2e/loginPage/index.cy.js
@@ -5,11 +5,13 @@ describe("Loginpage", () => {
         cy.visit("/autenticacao/");
     });
 
-    it("Verifica se é possivel logar com email ou cpf e senha", () => {
-        loginWith("Admin@local", "mapas123");
-        cy.visit("/autenticacao/");
-        loginWith("12345678902", "mapas123");
-    });
+  it("Verifica se é possivel logar com email ou cpf e senha", () => {
+      loginWith("Admin@local", "mapas123");
+      cy.get(".exit > a").click();
+      cy.visit("/autenticacao/");
+      loginWith("555.132.590-36", "Mapas12345!");
+      cy.contains("Minha conta");
+  });
 
     it("Garantir que se as informações estiverem incorretas o usuário será avisado sobre", () => {
         loginWith("blablabla", "mapas123");

--- a/src/cypress/e2e/opportunity/index.cy.js
+++ b/src/cypress/e2e/opportunity/index.cy.js
@@ -29,7 +29,9 @@ describe("Opportunity Page", () => {
 
     it("Garante que os filtros de oportunidades funcionam quando existem resultados para a busca textual", () => {
         cy.visit("/oportunidades");
-        cy.get(".search-filter__actions--form-input").type("f");
+
+        cy.get(".search-filter__actions--form-input").type("teste");
+
         cy.wait(1000);
 
         checkFilterCount();


### PR DESCRIPTION
Correções:

1.Agents Page (agentesPage/index.cy.js):
--> A classe que o cypress procurava não existia. Além disso, ao fazer a comparação se os números de agentes eram iguais, ele não estava pegando o texto dentro do elemento, e sim estava pegando o elemento em si e comparando com um número.

2.Homepage (footer/index.cy.js):
--> Uma função nao funcionava corretamente pois estava faltando o import de outra função.

3.Login (loginPage/index.cy.js):
--> Chamava uma função para testar login, mas a função não existia. Então criei a função para logar que aceita parametros.
--> Alguns erros lógicos no teste, por exemplo, mesmo que se desse erro no login ele aceitava como funcionando.

4.Homepage (homepage/full.cy.js):
--> Estava pegando o agente errado.

5.Opportunity Page(opportunity/index.cy.js) & Pagina de projetos(projectsPage/full.cy.js & Pagina de espaço(spacesPage/full.cy.js):
--> Novamente eles buscavam uma classe que não existia(element + '__color' dentro de um span com class upper), alterei tudo isso apenas no arquivo /workspace/mapas/src/cypress/commands/checkFilterCountOf.js

(cherry-pick da branch 'feat/arrumar-cypress')