### PR TITLE
Botão 'Limpar Filtros' das oportunidades agora funciona corretamente.

### DIFF
--- a/src/modules/Search/components/search-filter-opportunity/script.js
+++ b/src/modules/Search/components/search-filter-opportunity/script.js
@@ -33,6 +33,7 @@ app.component('search-filter-opportunity', {
             delete this.pseudoQuery['@verified'];
             delete this.pseudoQuery.registrationFrom;
             delete this.pseudoQuery.registrationTo;
+            this.pseudoQuery['term:area'].length = 0;
             this.$refs.form.reset();
         },
         actualDate() {


### PR DESCRIPTION
## Descrição

Antes o botão limpar filtros não limpava as áreas de interesse, porém resolvi isso agora.

