### PR TITLE
Retirada da seção home-developers da home

### DIFF
--- a/src/themes/Funarte/views/site/index.php
+++ b/src/themes/Funarte/views/site/index.php
@@ -1,0 +1,21 @@
+<?php 
+/**
+ * @var MapasCulturais\App $app
+ * @var MapasCulturais\Themes\BaseV2\Theme $this
+ */
+
+$this->import('
+    home-entities 
+    home-feature
+    home-header 
+    home-map 
+    home-opportunities 
+    home-register
+');
+?>
+<home-header></home-header>
+<home-opportunities></home-opportunities>
+<home-entities></home-entities>
+<home-feature></home-feature>
+<home-register></home-register>
+<home-map></home-map>


### PR DESCRIPTION
Sobreescrevendo o arquivo index.php/site/views no tema Funarte para retirar a importação do módulo "home-developers" e a utilização deste na home